### PR TITLE
Use custom zfs import service, since the builtin one tries to mount t…

### DIFF
--- a/docs/zfs.md
+++ b/docs/zfs.md
@@ -14,11 +14,20 @@ Use legacy mounts so systemd/NixOS controls ordering and dependencies.
 ```shell
 sudo zfs create datapool/<name>
 sudo zfs set mountpoint=legacy datapool/<name>
+# For encrypted drives that rely on a key from Colmena and are to be mounted manually.
+sudo zfs set canmount=noauto datapool/<name>
 ```
 
 Then add a `fileSystems` entry in `disks.nix`, keep pool roots with
-`mountpoint=none` and `canmount=off`, ensure `boot.zfs.extraPools`
-lists the pool, and set `networking.hostId`.
+`mountpoint=none` and `canmount=off`, and set `networking.hostId`.
+
+`boot.zfs.extraPools` creates a Systemd service that imports the pool at boot,
+but doesn't mount it. The `fileSystems` entry creates a Systemd mount unit that
+mounts the dataset at the specified mount point, and can be used to control
+dependencies for services that rely on the dataset. If there is an encrypted
+dataset the key will be required to be loaded before the import service can start.
+That's why a custom import service should be created instead of using the one
+created by extraPools. You must also set `canmount=noauto` on the encrypted dataset.
 
 ## Creating an encrypted parent dataset
 
@@ -31,6 +40,7 @@ sudo zfs create -o encryption=aes-256-gcm \
   -o keylocation=prompt \
   -o compression=zstd \
   -o mountpoint=/srv/media/private \
+  -o canmount=noauto \
   mediapool/private
 
 # Children datasets
@@ -139,7 +149,8 @@ There are two ways to mount ZFS datasets.
    - **Why you need it:** Since your root filesystem is on `ext4` (not ZFS),
      NixOS won't automatically look for ZFS pools unless you tell it to.
 
-> What if I removed the fileSystems entries and just used zfs automounting? Any reason not to do that?
+> What if I removed the fileSystems entries and just used zfs automounting? Any
+  reason not to do that?
 
 You can do that, and it is simpler in some ways, but there are specific reasons
 why the NixOS community (and the wiki) generally steers you toward the `legacy`

--- a/nix/machines/illmatic/disks.nix
+++ b/nix/machines/illmatic/disks.nix
@@ -88,8 +88,16 @@
   ];
 
   # zfs configuration
-  # Note: pool import is handled manually in system.nix to avoid
-  # loading encryption keys for encrypted datasets during activation
-  boot.zfs.devNodes = "/dev/disk/by-id"; # needed because pools were created using disk ids.
-  # boot.zfs.extraPools is intentionally omitted - see system.nix for custom import
+  boot.zfs = {
+    devNodes = "/dev/disk/by-id"; # needed because pools were created using disk ids.
+    forceImportRoot = false;
+    # Disable encryption credential loading for mediapool -
+    # encrypted dataset (mediapool/private) is manually unlocked via zfs-vault
+    requestEncryptionCredentials = false;
+  };
+
+  services = {
+    btrfs.autoScrub.enable = true;
+    zfs.autoScrub.enable = true;
+  };
 }

--- a/nix/machines/illmatic/disks.nix
+++ b/nix/machines/illmatic/disks.nix
@@ -88,8 +88,8 @@
   ];
 
   # zfs configuration
+  # Note: pool import is handled manually in system.nix to avoid
+  # loading encryption keys for encrypted datasets during activation
   boot.zfs.devNodes = "/dev/disk/by-id"; # needed because pools were created using disk ids.
-  boot.zfs.extraPools = [
-    "mediapool"
-  ];
+  # boot.zfs.extraPools is intentionally omitted - see system.nix for custom import
 }

--- a/nix/machines/illmatic/system.nix
+++ b/nix/machines/illmatic/system.nix
@@ -13,7 +13,7 @@ in
     loader.systemd-boot.enable = true;
     loader.efi.canTouchEfiVariables = true;
 
-    # Enable ZFS support
+    # Enable ZFS and btrfs support
     # https://openzfs.github.io/openzfs-docs/Getting%20Started/NixOS/index.html
     # https://nixos.org/manual/nixos/stable/options.html#opt-networking.hostId
     supportedFilesystems = [
@@ -21,15 +21,10 @@ in
       "zfs"
       "ext4"
     ];
-
-    zfs.forceImportRoot = false;
   };
 
   # Enable services
   services = {
-    btrfs.autoScrub.enable = true;
-    zfs.autoScrub.enable = true;
-
     # Route gateway admin web thru caddy to avoid ssl cert warnings
     caddy.virtualHosts."unifi.${settings.homeDomain}".extraConfig = ''
       reverse_proxy https://router.${settings.homeDomain} {
@@ -137,47 +132,6 @@ in
       immich-server = {
         after = [ "mnt-pictures.mount" ];
         requires = [ "mnt-pictures.mount" ];
-      };
-
-      # Disable stock ZFS import service and create a bare import that doesn't load keys
-      # The encrypted dataset will be manually unlocked via zfs-vault after Colmena deploys the key
-      zfs-import-mediapool.enable = false;
-
-      # Custom pool import that runs without loading encryption keys
-      # This replaces the auto-generated service from boot.zfs.extraPools
-      import-mediapool-bare = {
-        description = "Import ZFS pool 'mediapool' (without key loading)";
-        wantedBy = [
-          "zfs-mount.service"
-          "local-fs.target"
-        ];
-        after = [
-          "systemd-modules-load.service"
-          "systemd-udevd.service"
-          "zfs-import.target"
-        ];
-        before = [
-          "zfs-mount.service"
-          "local-fs.target"
-        ];
-
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          Restart = "on-failure";
-          RestartSec = "1s";
-        };
-
-        script = ''
-          # Import the pool if not already imported
-          if ! ${pkgs.zfs}/bin/zpool list mediapool >/dev/null 2>&1; then
-            echo "Importing mediapool..."
-            ${pkgs.zfs}/bin/zpool import -f -N -d /dev/disk/by-id mediapool
-            echo "Pool imported successfully."
-          else
-            echo "Pool mediapool already imported."
-          fi
-        '';
       };
     };
   };

--- a/nix/machines/illmatic/system.nix
+++ b/nix/machines/illmatic/system.nix
@@ -133,9 +133,52 @@ in
       };
     };
 
-    services.immich-server = {
-      after = [ "mnt-pictures.mount" ];
-      requires = [ "mnt-pictures.mount" ];
+    services = {
+      immich-server = {
+        after = [ "mnt-pictures.mount" ];
+        requires = [ "mnt-pictures.mount" ];
+      };
+
+      # Disable stock ZFS import service and create a bare import that doesn't load keys
+      # The encrypted dataset will be manually unlocked via zfs-vault after Colmena deploys the key
+      zfs-import-mediapool.enable = false;
+
+      # Custom pool import that runs without loading encryption keys
+      # This replaces the auto-generated service from boot.zfs.extraPools
+      import-mediapool-bare = {
+        description = "Import ZFS pool 'mediapool' (without key loading)";
+        wantedBy = [
+          "zfs-mount.service"
+          "local-fs.target"
+        ];
+        after = [
+          "systemd-modules-load.service"
+          "systemd-udevd.service"
+          "zfs-import.target"
+        ];
+        before = [
+          "zfs-mount.service"
+          "local-fs.target"
+        ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          Restart = "on-failure";
+          RestartSec = "1s";
+        };
+
+        script = ''
+          # Import the pool if not already imported
+          if ! ${pkgs.zfs}/bin/zpool list mediapool >/dev/null 2>&1; then
+            echo "Importing mediapool..."
+            ${pkgs.zfs}/bin/zpool import -f -N -d /dev/disk/by-id mediapool
+            echo "Pool imported successfully."
+          else
+            echo "Pool mediapool already imported."
+          fi
+        '';
+      };
     };
   };
 


### PR DESCRIPTION
…he encrypted drive that has canmount=auto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced ZFS encryption docs with guidance for encrypted datasets, canmount=noauto usage, and clearer mounting vs. auto-mount trade-offs; improved readability.
* **Chores / Configuration**
  * Adjusted system configuration around ZFS/btrfs handling and auto-scrub behavior.
  * Clarified that a secondary pool's encryption credentials are not loaded automatically and must be unlocked manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->